### PR TITLE
Doc updates & Support job control by calling `setsid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ Next, copy this binary into the firmware image:
 Then, it will be automatically executed by the instrumented kernel during system
 bootup after the 4th `execve()` call if the `firmadyne.execute` kernel parameter
 is set to 1 (this is the default).
+
+Notes
+====
+
+## ARM Serial Devices
+QEMU ARM guests do not currently support multiple serial consoles. You can build qemu with [this patch](https://unix.stackexchange.com/questions/479085/can-qemu-m-virt-on-arm-aarch64-have-multiple-serial-ttys-like-such-as-pl011-t/549798#549798) or try the [PANDA emulator](https://github.com/panda-re/panda) to run ARM guests with multiple serial devices.
+
+## Shell Usability
+If you start a serial console with `-serial stdio`, pressing ctrl-C, ctl-Z, or so on will be sent to the emulator itself. If you wish for these commands to be sent to the guest, you can use `-nographic` (if running with a single serial console), or `-serial telnet:localhost:4321,noserver,nowait -serial stdio` to expose a root shell on ttyS1 via telnet and the standard guest output on stdio. Then you can connect to the root console via telnet (with `telnet localhost 4321`) and press ctrl-C, ctrl-Z and have these commands sent directly into the guest.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Introduction
 ============
 
-This is a small binary that spawns a console on the `/dev/firmadyne` special
+This is a small binary that spawns a console on the `/firmadyne/ttyS1`` special
 character device at system startup. In conjunction with a patched filesystem
 and instrumented kernel, this allows an analyst to interact with an emulated
 firmware image through QEMU, since some firmware images do not spawn a terminal
@@ -19,5 +19,5 @@ Next, copy this binary into the firmware image:
 `cp console /firmadyne/console`
 
 Then, it will be automatically executed by the instrumented kernel during system
-bootup after the 4th `execve()` call if both `firmadyne.execute` and
-`firmadyne.syscall` kernel parameters are set to 1 (this is the default).
+bootup after the 4th `execve()` call if the `firmadyne.execute` kernel parameter
+is set to 1 (this is the default).

--- a/console.c
+++ b/console.c
@@ -5,10 +5,14 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-// Bind a shell to a serial console (/dev/firmadyne)
+// Bind a shell to a serial console (/firmadyne/ttyS1) and
+// ensure the session has support for job control (e.g.,
+// ctrl+c, ctrl+z)
 
 int main(int argc, char **argv) {
     int fd;
+
+    setsid();
 
     close(2);
     close(1);


### PR DESCRIPTION
This PR makes a minor modification in console.c so the spawned shell can support job control (e.g., ctrl-C and ctrl-Z).

The changes are split across 3 commits, the first makes some minor updates to the docs, the 2nd makes the change to console.c, and the third updates the docs to describe how to best use the generated shell and the limitations with ARM devices.

Prior to this PR, if you exposed a shell via telnet (i.e., with `-serial telnet:localhost:4321`), you'd see a warning from busybox's shell when it was started
```
$ telnet localhost 4321
[...]
BusyBox v1.23.2 (2021-06-14 02:21:16 IST) built-in shell (ash)

/bin/sh: can't access tty; job control turned off
/ # 
```
At this point, sending a ctrl-C would do nothing. If you run a command such as `top` your terminal would become unusable since you wouldn't be able to terminate it. Similarly, you wouldn't be able to send jobs into the background with ctrl-Z.

With this PR, the warning from busybox goes away and users can send ctrl-C or ctrl-Z into to the guest:
```
$ telnet localhost 4321
[...]

BusyBox v1.23.2 (2021-06-14 02:21:16 IST) built-in shell (ash)

/ # sleep 5
^C
/ #
```
